### PR TITLE
レイアウト崩れに対応

### DIFF
--- a/src/components/ChatBaseLayout/index.tsx
+++ b/src/components/ChatBaseLayout/index.tsx
@@ -32,6 +32,7 @@ export const ChatBaseLayout = ({
 						height: '100%',
 						backgroundColor: theme.palette.grey[100],
 						width: 240,
+						flexShrink: 0,
 					}}
 				>
 					{navigationBarContent}


### PR DESCRIPTION
# やったこと
- チャットが長くなった際に発生するレイアウト崩れに対応
- `flexShrink`を設定

# 結果
![image](https://github.com/user-attachments/assets/c547766c-9069-4a8f-9dcd-cc7b230f93ac)
