### PR TITLE
スレッド関係の処理の分離

### DIFF
--- a/src/features/chat/components/ChatFormContainer/index.tsx
+++ b/src/features/chat/components/ChatFormContainer/index.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import type { SendChatType } from '../../hooks/useSendChat';
 import { ChatForm } from '../ChatForm';
+import type { HandleSendChatType } from '../ChatMainContainer';
 
 type Props = {
-  sendChat: SendChatType;
+  sendChat: HandleSendChatType;
 };
 
 export const ChatFormContainer = ({ sendChat }: Props) => {

--- a/src/features/chat/components/ChatMain/index.tsx
+++ b/src/features/chat/components/ChatMain/index.tsx
@@ -1,11 +1,11 @@
 import { Box } from '@mui/material';
-import type { SendChatType } from '../../hooks/useSendChat';
 import type { ChatLogType } from '../../types';
 import { ChatFormContainer } from '../ChatFormContainer';
 import { ChatLogContainer } from '../ChatLogContainer';
+import type { HandleSendChatType } from '../ChatMainContainer';
 
 type Props = {
-  sendChat: SendChatType;
+  sendChat: HandleSendChatType;
   latestQuestion: string;
   latestAnswer: string;
   chatLog: ChatLogType;

--- a/src/features/chat/components/ChatMainContainer/index.tsx
+++ b/src/features/chat/components/ChatMainContainer/index.tsx
@@ -15,6 +15,9 @@ export const ChatMainContainer = () => {
 
   const router = useRouter();
 
+  /**
+   * ページを開いた際にURLパラメータからthreadIdを取得します。
+   */
   useEffect(() => {
     if (router.isReady) {
       const id = getThreadId();

--- a/src/features/chat/components/ChatMainContainer/index.tsx
+++ b/src/features/chat/components/ChatMainContainer/index.tsx
@@ -2,62 +2,21 @@ import { useRouter } from 'next/router';
 import { useCallback, useEffect, useState } from 'react';
 import { useSendChat } from '../../hooks/useSendChat';
 import type { SendChatArgument } from '../../hooks/useSendChat';
+import { useThreadId } from '../../hooks/useThreadId';
 import { useThreadMessages } from '../../hooks/useThreadMessages';
 import { ChatMain } from '../ChatMain';
 
 export type HandleSendChatType = (arg: SendChatArgument) => Promise<void>;
 
 export const ChatMainContainer = () => {
-  const [threadId, setThreadId] = useState<string | undefined>(undefined);
-
   const { sendChat, latestQuestion, latestAnswer, clearLatestAnswer } =
     useSendChat();
 
-  const router = useRouter();
-
-  /**
-   * ページを開いた際にURLパラメータからthreadIdを取得します。
-   */
-  useEffect(() => {
-    if (router.isReady) {
-      const id = getThreadId();
-      setThreadId(id);
-    }
-  }, [router.isReady]);
-
-  /**
-   * ルータークエリからthreadIdを取得します。
-   * @returns {string | undefined} 利用可能な場合、threadIdを返します。
-   */
-  const getThreadId = useCallback((): string | undefined => {
-    const queryThreadId = router.query.threadId;
-
-    if (Array.isArray(queryThreadId)) {
-      return queryThreadId[0];
-    }
-    return queryThreadId;
-  }, [router.query.threadId]);
+  const { threadId, setThreadId, getThreadId } = useThreadId();
 
   const { fetchThreadMessages } = useThreadMessages();
   const { data, refetch } = fetchThreadMessages(threadId);
   const chatLog = data ?? [];
-
-  /**
-   * 現在のthreadIdでURLパラメータの値を更新する。
-   */
-  useEffect(() => {
-    const currentThreadId = getThreadId();
-    if (currentThreadId && threadId && currentThreadId !== threadId) {
-      router.replace(
-        {
-          pathname: router.pathname,
-          query: { ...router.query, threadId },
-        },
-        undefined,
-        { shallow: true },
-      );
-    }
-  }, [getThreadId, threadId, router.pathname, router.replace, router.query]);
 
   /**
    * チャットメッセージを送信します。

--- a/src/features/chat/components/ChatMainContainer/index.tsx
+++ b/src/features/chat/components/ChatMainContainer/index.tsx
@@ -8,19 +8,13 @@ import { ChatMain } from '../ChatMain';
 export const ChatMainContainer = () => {
   const [threadId, setThreadId] = useState<string | undefined>(undefined);
 
-  const {
-    sendChat,
-    latestQuestion,
-    latestAnswer,
-    currentThreadId,
-    clearLatestAnswer,
-  } = useSendChat();
+  const { sendChat, latestQuestion, latestAnswer, clearLatestAnswer } =
+    useSendChat();
 
   const router = useRouter();
 
   useEffect(() => {
     const id = getThreadId();
-    console.log('id', id);
     setThreadId(id);
   }, []);
 
@@ -45,30 +39,34 @@ export const ChatMainContainer = () => {
    * 現在のthreadIdでURLパラメータの値を更新する。
    */
   useEffect(() => {
-    if (currentThreadId && router.query.thread !== currentThreadId) {
+    if (threadId && router.query.threadId !== threadId) {
       router.replace(
         {
           pathname: router.pathname,
-          query: { ...router.query, thread: currentThreadId },
+          query: { ...router.query, threadId },
         },
         undefined,
         { shallow: true },
       );
     }
-  }, [currentThreadId, router.pathname, router.replace, router.query]);
+  }, [threadId, router.pathname, router.replace, router.query]);
 
   /**
    * チャットメッセージを送信します。
    * @param {SendChatArgument} param0 - 送信するメッセージ。
    */
-  const handleSendChat = ({ message }: SendChatArgument) => {
+  const handleSendChat = async ({ message }: SendChatArgument) => {
     const threadId = getThreadId();
     if (threadId) {
       refetch();
     }
-
-    sendChat({ message, threadId });
     clearLatestAnswer();
+
+    const latestThreadId = await sendChat({ message, threadId });
+
+    if (latestThreadId) {
+      setThreadId(latestThreadId);
+    }
   };
 
   return (

--- a/src/features/chat/components/ChatMainContainer/index.tsx
+++ b/src/features/chat/components/ChatMainContainer/index.tsx
@@ -60,9 +60,9 @@ export const ChatMainContainer = () => {
     if (threadId) {
       refetch();
     }
-    clearLatestAnswer();
 
     const latestThreadId = await sendChat({ message, threadId });
+    clearLatestAnswer();
 
     if (latestThreadId) {
       setThreadId(latestThreadId);

--- a/src/features/chat/components/ChatMainContainer/index.tsx
+++ b/src/features/chat/components/ChatMainContainer/index.tsx
@@ -16,9 +16,11 @@ export const ChatMainContainer = () => {
   const router = useRouter();
 
   useEffect(() => {
-    const id = getThreadId();
-    setThreadId(id);
-  }, []);
+    if (router.isReady) {
+      const id = getThreadId();
+      setThreadId(id);
+    }
+  }, [router.isReady]);
 
   /**
    * ルータークエリからthreadIdを取得します。

--- a/src/features/chat/hooks/useSendChat.ts
+++ b/src/features/chat/hooks/useSendChat.ts
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import { useCallback, useState } from 'react';
 
 export type SendChatArgument = {
@@ -45,7 +44,7 @@ export const useSendChat = () => {
       }
 
       // 戻り値用にスレッドIDを初期化
-      let currentThreadId = '';
+      let newThreadId = '';
 
       while (true) {
         const { done, value } = await reader.read();
@@ -61,7 +60,7 @@ export const useSendChat = () => {
         for (const json of jsons) {
           try {
             if (json === '[DONE]') {
-              return; // 終端記号
+              return newThreadId; // 終端記号
             }
             const chunk = JSON.parse(json);
             const text = chunk.content;
@@ -69,16 +68,14 @@ export const useSendChat = () => {
             setLatestAnswer(text);
 
             // スレッドIDを保存
-            if (!currentThreadId && chunk.thread_id) {
-              currentThreadId = chunk.thread_id;
+            if (!newThreadId && chunk.thread_id) {
+              newThreadId = chunk.thread_id;
             }
           } catch (error) {
             console.error(error);
           }
         }
       }
-
-      return currentThreadId;
     },
     [],
   );

--- a/src/features/chat/hooks/useSendChat.ts
+++ b/src/features/chat/hooks/useSendChat.ts
@@ -5,7 +5,7 @@ export type SendChatArgument = {
   threadId?: string;
 };
 
-export type SendChatType = (arg: SendChatArgument) => void;
+export type SendChatType = (arg: SendChatArgument) => Promise<string>;
 
 export const useSendChat = () => {
   const [latestQuestion, setLatestQuestion] = useState<string>('');

--- a/src/features/chat/hooks/useSendChat.ts
+++ b/src/features/chat/hooks/useSendChat.ts
@@ -88,6 +88,7 @@ export const useSendChat = () => {
    */
   const clearLatestAnswer = useCallback(() => {
     setLatestAnswer('');
+    setLatestQuestion('');
   }, []);
 
   return {

--- a/src/features/chat/hooks/useSendChat.ts
+++ b/src/features/chat/hooks/useSendChat.ts
@@ -11,7 +11,6 @@ export type SendChatType = (arg: SendChatArgument) => void;
 export const useSendChat = () => {
   const [latestQuestion, setLatestQuestion] = useState<string>('');
   const [latestAnswer, setLatestAnswer] = useState<string>('');
-  const [currentThreadId, setCurrentThreadId] = useState<string>('');
 
   /**
    * チャットメッセージを送信する
@@ -45,6 +44,9 @@ export const useSendChat = () => {
         throw new Error('Failed to send chat message');
       }
 
+      // 戻り値用にスレッドIDを初期化
+      let currentThreadId = '';
+
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
@@ -68,15 +70,17 @@ export const useSendChat = () => {
 
             // スレッドIDを保存
             if (!currentThreadId && chunk.thread_id) {
-              setCurrentThreadId(chunk.thread_id);
+              currentThreadId = chunk.thread_id;
             }
           } catch (error) {
             console.error(error);
           }
         }
       }
+
+      return currentThreadId;
     },
-    [currentThreadId],
+    [],
   );
 
   /**
@@ -89,7 +93,6 @@ export const useSendChat = () => {
   return {
     latestQuestion,
     latestAnswer,
-    currentThreadId,
     sendChat,
     clearLatestAnswer,
   };

--- a/src/features/chat/hooks/useThreadId.ts
+++ b/src/features/chat/hooks/useThreadId.ts
@@ -1,0 +1,49 @@
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useState } from 'react';
+
+export const useThreadId = () => {
+  const [threadId, setThreadId] = useState<string | undefined>(undefined);
+  const router = useRouter();
+
+  /**
+   * ページを開いた際にURLパラメータからthreadIdを取得します。
+   */
+  useEffect(() => {
+    if (router.isReady) {
+      const id = getThreadId();
+      setThreadId(id);
+    }
+  }, [router.isReady]);
+
+  /**
+   * ルータークエリからthreadIdを取得します。
+   * @returns {string | undefined} 利用可能な場合、threadIdを返します。
+   */
+  const getThreadId = useCallback((): string | undefined => {
+    const queryThreadId = router.query.threadId;
+
+    if (Array.isArray(queryThreadId)) {
+      return queryThreadId[0];
+    }
+    return queryThreadId;
+  }, [router.query.threadId]);
+
+  /**
+   * 現在のthreadIdでURLパラメータの値を更新する。
+   */
+  useEffect(() => {
+    const currentThreadId = getThreadId();
+    if (currentThreadId && threadId && currentThreadId !== threadId) {
+      router.replace(
+        {
+          pathname: router.pathname,
+          query: { ...router.query, threadId },
+        },
+        undefined,
+        { shallow: true },
+      );
+    }
+  }, [getThreadId, threadId, router.pathname, router.replace, router.query]);
+
+  return { threadId, setThreadId, getThreadId };
+};


### PR DESCRIPTION
# やったこと
- スレッドIDの管理を`useSendChat`でやっていたので`useThreadId`に分離させた

# 結果
関心の分離ができた