### PR TITLE
新規チャットで最新のチャットが2回表示されるバグを解消

### DIFF
--- a/src/features/chat/components/ChatMainContainer/index.tsx
+++ b/src/features/chat/components/ChatMainContainer/index.tsx
@@ -31,6 +31,7 @@ export const ChatMainContainer = () => {
 
     if (latestThreadId !== threadId) {
       setThreadId(latestThreadId);
+      clearLatestAnswer();
     }
   };
 


### PR DESCRIPTION
# やったこと
新規チャットで最新のチャットが2回表示されるバグを解消

# 結果
新規チャットで最新のチャットが2回表示されるバグを解消