### PR TITLE
新規チャットクリック時に過去のチャットが残るバグに対応

### DIFF
--- a/src/features/chat/components/ChatMainContainer/index.tsx
+++ b/src/features/chat/components/ChatMainContainer/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useSendChat } from '../../hooks/useSendChat';
 import type { SendChatArgument } from '../../hooks/useSendChat';
 import { useThreadId } from '../../hooks/useThreadId';
@@ -15,6 +16,12 @@ export const ChatMainContainer = () => {
   const { fetchThreadMessages } = useThreadMessages();
   const { data, refetch } = fetchThreadMessages(threadId);
   const chatLog = data ?? [];
+
+  useEffect(() => {
+    if (!threadId) {
+      clearLatestAnswer();
+    }
+  }, [threadId, clearLatestAnswer]);
 
   /**
    * チャットメッセージを送信します。


### PR DESCRIPTION
# やったこと
新規チャットクリック時に過去のチャットが残るバグに対応した

# 結果
新規チャットクリック時に過去のチャットが残るバグが解消